### PR TITLE
Added accounts deployment and service manifests for Kubernetes

### DIFF
--- a/accounts.yml
+++ b/accounts.yml
@@ -1,0 +1,62 @@
+# Defines the API version for Kubernetes deployment resources
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: accounts-deployment  # Name of the deployment
+  labels:
+    app: accounts  # Label to identify the deployment
+spec:
+  replicas: 1  # Defines the number of pod replicas (increase for scalability)
+  selector:
+    matchLabels:
+      app: accounts  # Ensures the pods with this label are managed by this deployment
+  template:
+    metadata:
+      labels:
+        app: accounts  # Labels the pod to match the selector
+    spec:
+      containers:
+        - name: accounts  # Container name
+          image: bytes/accounts:s12  # Docker image used for this container (update as needed)
+          ports:
+            - containerPort: 8080  # Exposes port 8080 inside the container (should match service targetPort)
+
+          env:  # Environment variables are used to configure the Spring Boot application
+            - name: SPRING_APPLICATION_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: bank-configmap  # Retrieves the value from a ConfigMap
+                  key: ACCOUNTS_APPLICATION_NAME  # Specifies the key in the ConfigMap
+
+            - name: SPRING_PROFILES_ACTIVE
+              valueFrom:
+                configMapKeyRef:
+                  name: bank-configmap
+                  key: SPRING_PROFILES_ACTIVE  # Determines the active Spring profile (e.g., dev, prod)
+
+            - name: SPRING_CONFIG_IMPORT
+              valueFrom:
+                configMapKeyRef:
+                  name: bank-configmap
+                  key: SPRING_CONFIG_IMPORT  # Specifies the location of the Spring Cloud Config server
+
+            - name: EUREKA_CLIENT_SERVICEURL_DEFAULTZONE
+              valueFrom:
+                configMapKeyRef:
+                  name: bank-configmap
+                  key: EUREKA_CLIENT_SERVICEURL_DEFAULTZONE  # Points to the Eureka Server for service discovery
+
+---
+# Defines the API version for Kubernetes service resources
+apiVersion: v1
+kind: Service
+metadata:
+  name: accounts  # Name of the service
+spec:
+  selector:
+    app: accounts  # Connects the service to the pods labeled 'app: accounts'
+  type: LoadBalancer  # Exposes the service externally (change to NodePort for local use)
+  ports:
+    - protocol: TCP  # Communication protocol
+      port: 8080  # Port exposed externally
+      targetPort: 8080  # Maps to the containerPort inside the pod

--- a/eurekaserver.yml
+++ b/eurekaserver.yml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: eurekaserver  # Name of the container within the pod
-          image: eazybytes/eurekaserver:s12  # Docker image for Eureka Server (ensure this tag exists)
+          image: bytes/eurekaserver:s12  # Docker image for Eureka Server (ensure this tag exists)
 
           ports:
             - containerPort: 8070  # The port inside the container where Eureka runs
@@ -32,13 +32,13 @@ spec:
             - name: SPRING_APPLICATION_NAME
               valueFrom:
                 configMapKeyRef:
-                  name: eazybank-configmap  # Refers to a ConfigMap for environment variables (must exist)
+                  name: bank-configmap  # Refers to a ConfigMap for environment variables (must exist)
                   key: EUREKA_APPLICATION_NAME  # The key from ConfigMap providing the application name
 
             - name: SPRING_CONFIG_IMPORT
               valueFrom:
                 configMapKeyRef:
-                  name: eazybank-configmap  # Refers to a ConfigMap for importing external configs
+                  name: bank-configmap  # Refers to a ConfigMap for importing external configs
                   key: SPRING_CONFIG_IMPORT  # The key defining where to import configurations from
 
 ---


### PR DESCRIPTION
This PR adds Kubernetes manifests for deploying and exposing the Accounts Service. The deployment ensures proper integration with Eureka for service discovery and uses environment variables from a ConfigMap.

Apply the manifests:

kubectl apply -f accounts.yml

Next Steps & Enhancements:
🔹 Increase replica count for high availability.
🔹 Enable readiness and liveness probes for better health monitoring.
🔹 Consider switching to NodePort for local Kubernetes setups